### PR TITLE
feat: Add word and character count display

### DIFF
--- a/src/components/Editor.css
+++ b/src/components/Editor.css
@@ -498,3 +498,12 @@
 .theme-dracula .welcome-content p {
   color: #6272A4;
 } 
+
+.editor-footer {
+  padding: 4px 10px;
+  background-color: #252526;
+  color: #cccccc;
+  font-size: 0.8em;
+  text-align: right;
+  border-top: 1px solid #333; /* Optional: to match editor-header style */
+}

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -101,6 +101,21 @@ const EditorComponent = () => {
   const [content, setContent] = useState('');
   const [isEditorReady, setIsEditorReady] = useState(false);
   const [viewMode, setViewMode] = useState('code'); // 'code', 'preview', 'split'
+  const [wordCount, setWordCount] = useState(0);
+  const [characterCount, setCharacterCount] = useState(0);
+
+  const calculateCounts = (text) => {
+    const characters = text.length;
+    const trimmedText = text.trim();
+    const words = trimmedText === '' ? 0 : trimmedText.split(/\s+/).length;
+    return { words, characters };
+  };
+
+  useEffect(() => {
+    const { words, characters } = calculateCounts(content);
+    setWordCount(words);
+    setCharacterCount(characters);
+  }, [content]);
 
   useEffect(() => {
     const activeFileData = files.find(file => file.id === activeFile);
@@ -335,6 +350,9 @@ const EditorComponent = () => {
       </div>
       <div className="editor-content">
         {renderContent()}
+      </div>
+      <div className="editor-footer">
+        <span>Words: {wordCount}</span> | <span>Characters: {characterCount}</span>
       </div>
     </div>
   );

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -351,7 +351,7 @@ const EditorComponent = () => {
       <div className="editor-content">
         {renderContent()}
       </div>
-      <div className="editor-footer">
+      <div className="editor-footer" role="status">
         <span>Words: {wordCount}</span> | <span>Characters: {characterCount}</span>
       </div>
     </div>


### PR DESCRIPTION
Implements a real-time word and character counter in the editor.

- New state variables `wordCount` and `characterCount` were added to `EditorComponent.jsx`.
- A helper function `calculateCounts` calculates these values based on the editor's content.
- The counts are updated dynamically as you type using a `useEffect` hook.
- A new `editor-footer` div is added below the editor content area to display these counts.
- Styles for the `editor-footer` have been added to `Editor.css` to present it as a status bar.

This feature provides you with immediate feedback on your document's length, which is helpful for various writing tasks.